### PR TITLE
Add versioning for the client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 /spec/reports/
 /tmp/
 .vendor
+.idea/
+.rakeTasks
+y2signal.log
 
 # rspec failure tracking
 .rspec_status

--- a/lib/libyui_client.rb
+++ b/lib/libyui_client.rb
@@ -31,7 +31,7 @@ module LibyuiClient
       params[:id] = id if id
       params[:label] = label if label
       params[:type] = type if type
-      json = send_request(:get, '/widgets', params).first
+      json = send_request(:get, "/#{@@api_version}/widgets", params).first
       if debug_label
         json['debug_label'] == debug_label
       elsif inner_type

--- a/lib/libyui_client/config.yaml
+++ b/lib/libyui_client/config.yaml
@@ -1,0 +1,3 @@
+YUI_API_VERSION: "v1"
+YUI_HTTP_PORT: "14155"
+YUI_HTTP_HOST: "localhost"

--- a/lib/libyui_client/config_reader.rb
+++ b/lib/libyui_client/config_reader.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+# Client to interact with YAST UI rest api framework for integration testing
+module LibyuiClient
+
+  def self.read_config_value(key)
+    YAML.load_file(File.join(__dir__, 'config.yaml'))[key]
+  end
+
+end

--- a/lib/libyui_client/process_helper.rb
+++ b/lib/libyui_client/process_helper.rb
@@ -3,17 +3,27 @@
 require 'timeout'
 require 'socket'
 require 'rainbow'
+require 'libyui_client/config_reader'
 
 # Client to interact with YAST UI rest api framework for integration testing
 module LibyuiClient
   # default timeout for process
   DEFAULT_TIMEOUT_PROCESS = 20
 
+  # set the host for the application under control
+  def self.set_host
+    ENV['YUI_HTTP_HOST'] ||= read_config_value('YUI_HTTP_HOST')
+  end
+
   # set the application introspection port for communication
   def self.set_port
-    # 14155 is currently an unassigned port
-    ENV['YUI_HTTP_PORT'] ||= '14155'
+    ENV['YUI_HTTP_PORT'] ||= read_config_value('YUI_HTTP_PORT')
     ENV['YUI_HTTP_PORT']
+  end
+
+  # set libyui-rest-api API version
+  def self.set_api_version
+    ENV['YUI_API_VERSION'] ||= read_config_value('YUI_API_VERSION')
   end
 
   # is the target port open?
@@ -44,8 +54,9 @@ module LibyuiClient
   # start the application in background
   # @param application [String] the command to start
   def self.start_app(application)
-    @@app_host = 'localhost'
+    @@app_host = set_host
     @@app_port = set_port
+    @@api_version = set_api_version
 
     # another app already running?
     if port_open?(@@app_host, @@app_port)

--- a/lib/libyui_client/rest_api_client.rb
+++ b/lib/libyui_client/rest_api_client.rb
@@ -32,6 +32,15 @@ module LibyuiClient
     end
   end
 
+  def self.check_api_version
+    res = send_request(:get, '/version', {})
+    unless res['api_version'] == "#{@@api_version}"
+      raise 'libyui-rest-api API version does not correspond to the version the Client expects.' +
+            "\nRest API version: " + res['api_version'] +
+            "\nClient expects: #{@@api_version}"
+    end
+  end
+
   def self.send_request(method, path, params = {})
     uri = URI("http://#{@@app_host}:#{@@app_port}")
     uri.path = path
@@ -69,6 +78,6 @@ module LibyuiClient
     params[:type] = type if type
     params[:value] = value if value
 
-    send_request(:post, '/widgets', params)
+    send_request(:post, "/#{@@api_version}/widgets", params)
   end
 end

--- a/lib/libyui_client/widget_controller.rb
+++ b/lib/libyui_client/widget_controller.rb
@@ -12,6 +12,6 @@ module LibyuiClient
     params[:value] = value if value
     params[:column] = column if column
 
-    send_request(:post, '/widgets', params)
+    send_request(:post, "/#{@@api_version}/widgets", params)
   end
 end

--- a/spec/libyui_client_spec.rb
+++ b/spec/libyui_client_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe LibyuiClient, :type => :aruba do
   context "Running non-destructive scenarios:" do
     it "yast2 host" do
       LibyuiClient.start_app('/usr/sbin/yast2 host')
+      LibyuiClient.check_api_version
       #LibyuiClient.attach('localhost', 14155)
       LibyuiClient.find_widget(id: 'wizard', debug_label: 'Host Configuration')
       LibyuiClient.find_widget(id: 'add').click


### PR DESCRIPTION
**NOTE: This PR is dependent on https://github.com/libyui/libyui-rest-api/pull/4 will be merged. So, please do not merge it until the PR will be merged.**

LibYUI Rest API project introduced versioning. The commit adds the
appropriate versioning for the client, so that client will be compatible
with the respective API.

Related ticket: https://progress.opensuse.org/issues/62531