### PR TITLE
Сreate unit tests for widgets

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,9 @@ Lint/RaiseException:
 Lint/StructNewOverride:
   Enabled: true
 
+Lint/UriEscapeUnescape:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - "**/*_spec.rb"
@@ -33,3 +36,6 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+Metrics/ModuleLength:
+  Max: 500

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,15 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
+
+task :integration do
+  RSpec::Core::RakeTask.new(:integration) do |t|
+    t.pattern = 'spec/widgets/*_spec.rb'
+  end
+end
+
+task :unit do
+  RSpec::Core::RakeTask.new(:unit) do |t|
+    t.pattern = 'spec/unit/**/*_spec.rb'
+  end
+end

--- a/spec/unit/http/http_client_spec.rb
+++ b/spec/unit/http/http_client_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+module LibyuiClient
+  module Http
+    RSpec.describe HttpClient do
+      let(:http) { Net::HTTPSuccess.new('1.1', 200, 'OK') }
+      before { allow(http).to receive(:body).and_return('{"id": "foo"}') }
+      describe '#http_get' do
+        context 'makes a GET request' do
+          it 'returns a new LibyuiClient::Http::Response' do
+            expect_any_instance_of(Net::HTTP).to receive(:request).with(an_instance_of(Net::HTTP::Get))
+                                                                  .and_return(http)
+            escapedurl = URI.escape('http://test.org')
+            uri = URI.parse(escapedurl)
+            response = HttpClient.http_get(uri)
+            expect(response.code).to eq(200)
+            expect(response).to have_attributes(code: 200, body: '{"id": "foo"}')
+            expect(response.body).to eq('{"id": "foo"}')
+          end
+        end
+      end
+
+      describe '#http_post' do
+        context 'makes a POST request' do
+          it 'returns a new LibyuiClient::Http::Response' do
+            expect_any_instance_of(Net::HTTP).to receive(:request).with(an_instance_of(Net::HTTP::Post))
+                                                                  .and_return(http)
+            escapedurl = URI.escape('http://test.org?widgets')
+            uri = URI.parse(escapedurl)
+            response = HttpClient.http_post(uri)
+            expect(response.code).to eq(200)
+            expect(response.body).to eq('{"id": "foo"}')
+          end
+        end
+      end
+
+      describe '#compose_uri' do
+        context 'when different port is defined' do
+          it 'returns the correct port' do
+            expected_port = 9999
+            actual_url = HttpClient.compose_uri('test.org', expected_port, '/widgets', {})
+            aggregate_failures "failures when actual is #{actual_url}" do
+              expect(actual_url).to be_instance_of(URI::HTTP)
+              expect(actual_url.port).to eq(expected_port)
+            end
+          end
+        end
+        context 'when request does not contain filter parameter' do
+          it 'returns url without filter' do
+            expected_url = 'http://test.org/widgets?'
+            actual_url = HttpClient.compose_uri('test.org', 80, '/widgets', {})
+            aggregate_failures "failures when actual is #{actual_url}" do
+              expect(actual_url).to be_instance_of(URI::HTTP)
+              expect(actual_url.to_s).to eq(expected_url)
+            end
+          end
+        end
+        context 'when request has filter parameter' do
+          it 'returns url with filter' do
+            expected_url = 'http://test.org/widgets?id=foo'
+            actual_url = HttpClient.compose_uri('test.org', 80, '/widgets', { id: 'foo' })
+            aggregate_failures "failures when actual is #{actual_url}" do
+              expect(actual_url).to be_instance_of(URI::HTTP)
+              expect(actual_url.to_s).to eq(expected_url)
+            end
+          end
+        end
+        context 'when request contain filter parameter with action' do
+          it 'returns url with filter and action' do
+            expected_url = 'http://test.org/widgets?id=foo&action=PRESS'
+            actual_url = HttpClient.compose_uri('test.org', 80, '/widgets', { id: 'foo', action: 'PRESS' })
+            aggregate_failures "failures when actual is #{actual_url}" do
+              expect(actual_url).to be_instance_of(URI::HTTP)
+              expect(actual_url.to_s).to eq(expected_url)
+            end
+          end
+        end
+        context 'when url has protocol' do
+          it 'raises InvalidComponentError' do
+            expect { HttpClient.compose_uri('http://test.org', 80, 'widgets', { id: 'foo' }) }
+              .to raise_error(URI::InvalidComponentError)
+          end
+        end
+        context 'when filter do not have /' do
+          it 'rasise InvalidComponentError' do
+            expect { HttpClient.compose_uri('test.org', 80, 'widgets', { id: 'foo' }) }
+              .to raise_error(URI::InvalidComponentError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/http/widget_controller_spec.rb
+++ b/spec/unit/http/widget_controller_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+module LibyuiClient
+  module Http
+    RSpec.describe WidgetController do
+      let(:http) { double('http', { code: 200, is_a?: true, body: '{ "id": "foo" }' }) }
+      let(:httpclient) { instance_double(HttpClient) }
+      before { allow(Net::HTTP).to receive(:get_response).and_return http }
+
+      describe '#find' do
+        context 'GET request contains valid filter' do
+          it 'returns a new LibyuiClient::Http::Response' do
+            allow(http).to receive(:request).with(an_instance_of(Net::HTTP::Get)).and_return(Net::HTTPResponse)
+            allow(Net::HTTPResponse).to receive(:body).and_return(http)
+            allow(httpclient).to receive(:compose_uri)
+            allow(httpclient).to receive(:http_get)
+
+            widget_controller = WidgetController.new(host: 'test.org', port: 9999)
+            response = widget_controller.find({ id: 'foo' }, timeout: 5, interval: 0.5)
+            expect(response).to be_instance_of(Response)
+            expect(response.body).to include(id: 'foo')
+          end
+        end
+      end
+
+      describe '#send_action' do
+        context 'POST request with filter' do
+          it 'returns a new LibyuiClient::Http::Response' do
+            allow(http).to receive(:request).with(an_instance_of(Net::HTTP::Post)).and_return(Net::HTTPResponse)
+            allow(Net::HTTPResponse).to receive(:body).and_return(http)
+            allow(httpclient).to receive(:compose_uri)
+            allow(httpclient).to receive(:http_post)
+            widget_controller = WidgetController.new(host: 'test.org', port: 9999)
+            response = widget_controller.find({ id: 'foo' }, timeout: 5, interval: 0.5)
+            expect(response).to be_instance_of(Response)
+            expect(response.body).to include(id: 'foo')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/widgets/base_spec.rb
+++ b/spec/unit/widgets/base_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+module LibyuiClient
+  module Widgets
+    RSpec.describe Base do
+      let(:widget_controller) { instance_double('widget_controller') }
+      let(:widget_filter) { { id: 'foo' } }
+      describe '.Base' do
+        context 'when be initialized with default timeout and interval' do
+          it 'has a subclass with default timeout and interval' do
+            @obj = Button.new(widget_controller, widget_filter)
+            aggregate_failures 'for .Button' do
+              expect(@obj).to be_instance_of(Button)
+              expect(@obj.instance_eval('@timeout', __FILE__, __LINE__)).to equal(5)
+              expect(@obj.instance_eval('@interval', __FILE__, __LINE__)).to equal(0.5)
+            end
+          end
+        end
+        context 'when be initialized with custom timeout' do
+          it 'has a class with new timeout' do
+            LibyuiClient.timeout = 2
+            @obj = Checkbox.new(widget_controller, widget_filter)
+            aggregate_failures 'for .Checkbox' do
+              expect(@obj).to be_instance_of(Checkbox)
+              expect(@obj.instance_eval('@timeout', __FILE__, __LINE__)).to equal(2)
+              expect(@obj.instance_eval('@interval', __FILE__, __LINE__)).to equal(0.5)
+            end
+          end
+        end
+        context 'when be initialized with custom interval' do
+          it 'has a class with new interval and still uses the new timeout' do
+            LibyuiClient.interval = 2
+            @obj = Combobox.new(widget_controller, widget_filter)
+            aggregate_failures 'for .Combobox' do
+              expect(@obj).to be_instance_of(Combobox)
+              expect(@obj.instance_eval('@timeout', __FILE__, __LINE__)).to equal(2)
+              expect(@obj.instance_eval('@interval', __FILE__, __LINE__)).to equal(2)
+            end
+          end
+        end
+      end
+
+      describe '#exists?' do
+        let(:response) { instance_double('Response', { body: '[{ "id": "foo", "debug_label": "Cancel" }]' }) }
+        subject { Base.new(widget_controller, widget_filter) }
+
+        context 'when filter exist' do
+          it 'returns true' do
+            expect(widget_controller).to receive(:find).and_return(response)
+            expect(subject.exists?).to be_truthy
+          end
+        end
+        context 'non-existent widget' do
+          it 'returns false' do
+            allow(widget_controller).to receive(:find) do
+              raise(Error::WidgetNotFoundError)
+            end
+            @obj = Base.new(widget_controller, { id: '' })
+            expect(subject.exists?).to be_falsy
+          end
+        end
+      end
+
+      describe '#property' do
+        let(:response) { instance_double('Response', { body: [{ id: 'foo', debug_label: 'Cancel' }] }) }
+        before do
+          allow(widget_controller).to receive(:find).and_return(response)
+          @obj = Base.new(widget_controller, widget_filter)
+        end
+        context 'when the property exists' do
+          it 'returns the value of the property' do
+            expect(@obj.property(:id)).to eq('foo')
+          end
+        end
+      end
+
+      describe '#action' do
+        pending
+      end
+
+      describe '#collect_all' do
+        let(:widget1) do
+          { 'class': 'YCheckBox',
+            debug_label: 'Change the Time Now',
+            id: 'change_now',
+            label: 'Chan&ge the Time Now',
+            notify: true,
+            value: true }
+        end
+        let(:widget2) do
+          { 'class': 'YCheckBox',
+            debug_label: 'Change the Date Now',
+            id: 'change_now2',
+            label: 'Chan&ge the Date Now',
+            notify: true,
+            value: true }
+        end
+        let(:response) { instance_double('Response', { body: [widget1, widget2] }) }
+        before do
+          allow(widget_controller).to receive(:find).and_return(response)
+          @obj = Checkbox.new(widget_controller, widget_filter)
+        end
+        context 'when response contins two Widgets' do
+          it 'returns an Array of two new Widgets' do
+            arr = @obj.collect_all
+            expect(arr).to be_instance_of(Array)
+            arr.each do |widget|
+              expect(widget).to be_instance_of(Checkbox)
+            end
+            expect(arr.size).to eq(2)
+          end
+        end
+      end
+
+      describe '#enabled?' do
+        context 'when widget value is true' do
+          subject { Base.new(widget_controller, widget_filter) }
+          it 'returns true' do
+            response = instance_double('Response', { body: [{ id: 'foo',
+                                                              debug_label: 'Cancel',
+                                                              enabled: true }] })
+            allow(widget_controller).to receive(:find).and_return(response)
+            expect(subject.enabled?).to be_truthy
+          end
+        end
+        context 'when widget value does not have "enabled" property' do
+          subject(:widget) { Base.new(widget_controller, widget_filter) }
+          it 'is counted as enabled and returns true' do
+            allow(widget).to receive(:property).and_return(nil)
+            expect(widget.enabled?).to be_truthy
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/widgets/button_spec.rb
+++ b/spec/unit/widgets/button_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+module LibyuiClient
+  module Widgets
+    RSpec.describe Button do
+      let(:widget_controller) { instance_double('widget_controller') }
+      let(:widget_filter) { { id: 'foo' } }
+      subject { Button.new(widget_controller, widget_filter) }
+      describe '#click' do
+        it 'has a request with action press' do
+          allow(widget_controller).to receive(:send_action) {}
+          expect(subject).to receive(:action).with({ action: 'press' })
+          subject.click
+        end
+      end
+
+      describe '#fkey' do
+        it 'returns the correct fkey number' do
+          response = double('Response', { body: [{ id: 'cancel',
+                                                   debug_label: 'Cancel',
+                                                   fkey: 9 }] })
+          allow(widget_controller).to receive(:find).and_return(response)
+          allow(widget_controller).to receive(:property)
+          expect(subject).to receive(:fkey).and_return(9)
+          subject.fkey
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/widgets/checkbox_spec.rb
+++ b/spec/unit/widgets/checkbox_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+module LibyuiClient
+  module Widgets
+    RSpec.describe Checkbox do
+      let(:widget_controller) { instance_double('widget_controller') }
+      let(:widget_filter) { { id: 'change_now' } }
+      subject { Checkbox.new(widget_controller, widget_filter) }
+      describe '#toggle' do
+        it 'has a request with action toggle' do
+          allow(widget_controller).to receive(:send_action)
+          expect(subject).to receive(:action).with({ action: 'toggle' })
+          expect(subject.toggle).not_to be_nil
+        end
+      end
+
+      describe '#check' do
+        it 'has a request with action check' do
+          allow(widget_controller).to receive(:send_action)
+          expect(subject).to receive(:action).with({ action: 'check' })
+          expect(subject.check).not_to be_nil
+        end
+      end
+
+      describe '#uncheck' do
+        it 'has a request with action uncheck' do
+          allow(widget_controller).to receive(:send_action)
+          expect(subject).to receive(:action).with({ action: 'uncheck' })
+          expect(subject.uncheck).not_to be_nil
+        end
+      end
+
+      describe '#checked?' do
+        it 'should return the correct state of the component' do
+          response = double('Response', { body: [{ 'class': 'YCheckBox',
+                                                   debug_label: 'Change the Time Now',
+                                                   id: 'change_now',
+                                                   label: 'Chan&ge the Time Now',
+                                                   notify: true,
+                                                   value: true }] })
+          allow(widget_controller).to receive(:find).and_return(response)
+          expect(subject.checked?).to be_truthy
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/widgets/combobox_spec.rb
+++ b/spec/unit/widgets/combobox_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+module LibyuiClient
+  module Widgets
+    RSpec.describe Combobox do
+      let(:widget_controller) { instance_double('widget_controller') }
+      let(:widget_filter) { { id: 'test_combo' } }
+      subject { Combobox.new(widget_controller, widget_filter) }
+      describe '#select' do
+        it 'has a request with action select and correct value' do
+          allow(widget_controller).to receive(:send_action)
+          expect(subject).to receive(:action).with({ action: 'select', value: 'Any (Highest Available)' })
+          expect(subject.select('Any (Highest Available)')).to be_instance_of(Combobox)
+        end
+      end
+
+      describe '#items' do
+        it 'can return list of the combos of the widget' do
+          response = double('Response', { body: [{ 'class': 'YCombobox',
+                                                   columns: 1,
+                                                   id: 'test_combo',
+                                                   items: [{ label: 'Any (Highest Available)',
+                                                             selected: true },
+                                                           { label: 'Force NFSv3' }],
+                                                   items_count: 2 }] })
+          expect(widget_controller).to receive(:find).and_return(response)
+          expect(subject.items).to eq(['Any (Highest Available)', 'Force NFSv3'])
+        end
+      end
+
+      describe '#selected_item' do
+        it 'returns the selected combo item' do
+          response = double('Response', { body: [{ 'class': 'YCombobox',
+                                                   columns: 1,
+                                                   id: 'test_combo',
+                                                   items: [{ label: 'Any (Highest Available)',
+                                                             selected: true },
+                                                           { label: 'Force NFSv3' }],
+                                                   items_count: 2,
+                                                   value: 'Any (Highest Available)' }] })
+          expect(widget_controller).to receive(:find).and_return(response)
+          expect(subject.selected_item).to eq('Any (Highest Available)')
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/widgets/radiobutton_spec.rb
+++ b/spec/unit/widgets/radiobutton_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+module LibyuiClient
+  module Widgets
+    RSpec.describe Radiobutton do
+      let(:widget_controller) { instance_double('widget_controller') }
+      let(:widget_filter) { { id: 'manual' } }
+      subject { Radiobutton.new(widget_controller, widget_filter) }
+      describe '#select' do
+        it 'call select action' do
+          allow(widget_controller).to receive(:send_action)
+          expect(subject).to receive(:action).with({ action: 'select' })
+          expect(subject.select).to be_instance_of(Radiobutton)
+        end
+      end
+
+      describe '#selected' do
+        it 'should return radiobutton value' do
+          response = double('Response', { body: [{ 'class': 'YRadiobutton',
+                                                   debug_label: 'Manually',
+                                                   id: 'manual',
+                                                   label: '&Manually',
+                                                   notify: true,
+                                                   value: false }] })
+          allow(widget_controller).to receive(:find).and_return(response)
+          allow(widget_controller).to receive(:property)
+          expect(subject.selected?).to be_falsy
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/widgets/table_spec.rb
+++ b/spec/unit/widgets/table_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+module LibyuiClient
+  module Widgets
+    RSpec.describe Table do
+      let(:widget_controller) { instance_double('widget_controller') }
+      let(:widget_filter) { { id: 'foo' } }
+      subject { Table.new(widget_controller, widget_filter) }
+      describe '#select_row' do
+        it 'sends select action' do
+          allow(widget_controller).to receive(:send_action)
+          expect(subject).to receive(:action).with({ action: 'select', column: 0, value: 'test.item.1' })
+          expect(subject.select_row(value: 'test.item.1', column_id: 0)).to be_instance_of(Table)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/widgets/textbox_spec.rb
+++ b/spec/unit/widgets/textbox_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+module LibyuiClient
+  module Widgets
+    RSpec.describe Textbox do
+      let(:widget_controller) { instance_double('widget_controller') }
+      let(:widget_filter) { { id: 'aliases' } }
+      subject { Textbox.new(widget_controller, widget_filter) }
+      describe '#set' do
+        it 'sends POST with action enter_text and correct value' do
+          expect(subject).to receive(:action).with({ action: 'enter_text', value: 'test' })
+          subject.set('test')
+        end
+      end
+
+      describe '#value' do
+        it 'should return the text of the :value' do
+          response = double('Response', { body: [{ 'class': 'InputField',
+                                                   debug_label: 'Host Aliases',
+                                                   hstretch: true,
+                                                   id: 'aliases',
+                                                   label: 'Hos&t Aliases',
+                                                   password_mode: false,
+                                                   value: 'test' }] })
+          allow(widget_controller).to receive(:find).and_return(response)
+          allow(widget_controller).to receive(:property)
+          expect(subject.value).to eq('test')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
There is basic coverage for the most of the modules. Many things stayed out so this PR wont take for ever. 

Widgets:
- instance_double instead of simple double. this ensures that the instance can be validated and it is not a random object.
- most of the widgets just verify that the request are composed with the correct parameters. for instance when a widget triggers an action, it checks with `expect` what it should receive. In some cases when the expectation is set the action of the widget is coming afterwards. 
- `Base#action` is pending. The reason is that the expectations here is strange because i should mock two objects and i would end up with testing the doubles.

http:
- here there were many ways to do this. There is `WebMock`(which already used in the integration tests), `Fakes`(also used in integration), `VCR`(however it reqiures to do an actual request first). There is a lot of mocking here but i tried to keep it 'pure' with rspec-mocks and following the guides that Rodion offered(posting here because it can help with the review https://rspec.rubystyle.guide/ besides http://www.betterspecs.org/ which also has some good examples). 