### PR TITLE
Add widgets for Expert Partitioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ button.click
 ## Installing libyui_client
 
 As soon as the gem is in development, run the following command from command line:
+
 ```
 gem "libyui_client", :git => "git@github.com:jknphy/libyui_client.git"
 ```
@@ -41,50 +42,93 @@ Here are examples of usage:
 ### Button
 
 ```ruby
-app = LibyuiClient::App.new(host: 'localhost', port: '9999')
 app.button(id: 'test_id').click  # clicks the button with id 'test_id'
-app.button(label: 'test_label', id: 'test_id').debug_label # get 'debug_label' value
+app.button(label: 'test_label').debug_label # get 'debug_label' value with label 'test_label'
 ```
 
 ### Checkbox
 
 ```ruby
-app = LibyuiClient::App.new(host: 'localhost', port: '9999')
 app.checkbox(id: 'test_id').check  # checks the checkbox with id 'test_id'
-app.checkbox(id: 'test_id').uncheck  # unchecks the checkbox with id 'test_id'
+app.checkbox(label: 'test_label').checked? # gets the state of checkbox with label 'test_label'
 app.checkbox(id: 'test_id').toggle # toggles the checkbox with id 'test_id'
-app.checkbox(label: 'test_label', id: 'test_id').checked? # gets the state of checkbox
+app.checkbox(id: 'test_id').uncheck  # unchecks the checkbox with id 'test_id'
+
 ```
 
 ### Combobox
 
 ```ruby
-app = LibyuiClient::App.new(host: 'localhost', port: '9999')
-app.combobox(id: 'test_id').select  # selects the checkbox with id 'test_id'
 app.combobox(id: 'test_id').items  # gets all available items for combobox with id 'test_id'
-app.combobox(id: 'test_id').selected_item # gets the selected item
+app.combobox(id: 'test_id').select  # selects the checkbox with id 'test_id'
+app.combobox(id: 'test_id').selected_item # gets the selected item in combobox with id 'test_id'
+```
+### Label
+```ruby
+app.label(id: 'test_id').heading?  # gets if label has bold font respresentation with id 'test_id'
+app.label(id: 'test_id').text  # gets text from label with id 'test_id'
+```
+
+### Menubutton
+```ruby
+app.menubutton(id: 'test_id').click('button1')  # clicks on 'button1' of menubutton with id 'test_id'
+```
+
+### Numberbox
+```ruby
+app.numberbox(id: 'test_id').min_value  # gets min value to be set in numberbox with id 'test_id'
+app.numberbox(id: 'test_id').max_value  # gets max value to be set in numberbox with id 'test_id'
+app.numberbox(id: 'test_id').set(99)  # sets 99 to numberbox with id 'test_id'
+app.numberbox(id: 'test_id').value  # gets value from numberbox with id 'test_id'
 ```
 
 ### Radiobutton
 
 ```ruby
-app = LibyuiClient::App.new(host: 'localhost', port: '9999')
 app.radiobutton(id: 'test_id').select  # selects the radiobutton with id 'test_id'
-app.radiobutton(id: 'test_id').selected?  # gets the state of radiobutton
+app.radiobutton(id: 'test_id').selected?  # gets the state of radiobutton with id 'test_id'
+```
+
+### Richtext
+```ruby
+app.richtext(id: 'test_id').click_link('test_link')  # clicks on link "test_link" with id 'test_id'
+app.richtext(id: 'test_id').text  # gets text from richtext
+```
+
+### Tab
+
+```ruby
+app.tab(id: 'test_id').items  # gets items from tab with id 'test_id'
+app.tab(id: 'test_id').select(value: 'item')  # selects specific tab with id 'test_id'
+app.tab(id: 'test_id').selected_item  # gets selected tab for tab with id 'test_id'
+
 ```
 
 ### Table
 
 ```ruby
-app = LibyuiClient::App.new(host: 'localhost', port: '9999')
-app.table(id: 'test_table').select_row(value: 'test.item.1', column_id: 0)  # selects the row in table with test.item.1
+app.table(id: 'test_id').empty? # checks if there is not rows in table with id 'test_id'
+app.table(id: 'test_id').items  # gets rows in the table with id 'test_id'
+app.table(id: 'test_id').select(value: 'test.item.1', # selects row in table with value test.item.1
+                                column: 'test.header')  # and column test.header
+app.table(id: 'test_id').seleted_items # gets items currently selected in table with id 'test_id'
+
 ```
 
 ### Textbox
 ```ruby
-app = LibyuiClient::App.new(host: 'localhost', port: '9999')
+app.textbox(id: 'test_id').max_length
 app.textbox(id: 'test_id').set('Test Text')  # sets "Test Text" to textbox with id 'test_id'
-app.textbox(id: 'test_id').value  # gets value from textbox
+app.textbox(id: 'test_id').password? # checks password mode for textbox with id 'test_id'
+app.textbox(id: 'test_id').valid_chars # checks valid chars for textbox with id 'test_id'
+app.textbox(id: 'test_id').value  # gets value from textbox with id 'test_id'
+```
+
+### Tree
+```ruby
+app.tree(id: 'test_id').items  # gets items from tree with id 'test_id'
+app.tree(id: 'test_id').select('node1|node1_2')  # selects item in tree with id 'test_id'
+app.tree(id: 'test_id').selected_item  # gets currently highlighted item from tree with id 'test_id'
 ```
 
 ## Filters

--- a/lib/libyui_client/app.rb
+++ b/lib/libyui_client/app.rb
@@ -42,6 +42,36 @@ module LibyuiClient
       Widgets::Combobox.new(@widget_controller, Validate.filter(filter))
     end
 
+    # Initializes new instance of Label with the filter provided.
+    # Does not make request to libyui-rest-api.
+    # @param filter [Hash] filter to find a widget
+    # @return [Widgets::Label] new instance of Label
+    # @example
+    #   app.label(id: 'id', label: 'label', type: 'YLabel')
+    def label(filter)
+      Widgets::Label.new(@widget_controller, Validate.filter(filter))
+    end
+
+    # Initializes new instance of Menubutton with the filter provided.
+    # Does not make request to libyui-rest-api.
+    # @param filter [Hash] filter to find a widget
+    # @return [Widgets::Menubutton] new instance of Menubutton
+    # @example
+    #   app.menubutton(id: 'id', label: 'label', type: 'YMenuButton')
+    def menubutton(filter)
+      Widgets::Menubutton.new(@widget_controller, Validate.filter(filter))
+    end
+
+    # Initializes new instance of Numberbox with the filter provided.
+    # Does not make request to libyui-rest-api.
+    # @param filter [Hash] filter to find a widget
+    # @return [Widgets::Numberbox] new instance of Numberbox
+    # @example
+    #   app.numberbox(id: 'id', label: 'label', type: 'YIntField')
+    def numberbox(filter)
+      Widgets::Numberbox.new(@widget_controller, Validate.filter(filter))
+    end
+
     # Initializes new instance of Radiobutton with the filter provided.
     # Does not make request to libyui-rest-api.
     # @param filter [Hash] filter to find a widget
@@ -50,6 +80,26 @@ module LibyuiClient
     #   app.checkbox(id: 'id', label: 'label', type: 'YRadioButton')
     def radiobutton(filter)
       Widgets::Radiobutton.new(@widget_controller, Validate.filter(filter))
+    end
+
+    # Initializes new instance of Richtext with the filter provided.
+    # Does not make request to libyui-rest-api.
+    # @param filter [Hash] filter to find a widget
+    # @return [Widgets::Richtext] new instance of Richtext
+    # @example
+    #   app.richtext(id: 'id', label: 'label', type: 'YLabel')
+    def richtext(filter)
+      Widgets::Richtext.new(@widget_controller, Validate.filter(filter))
+    end
+
+    # Initializes new instance of Tab with the filter provided.
+    # Does not make request to libyui-rest-api.
+    # @param filter [Hash] filter to find a widget
+    # @return [Widgets::Tab] new instance of Tab
+    # @example
+    #   app.tab(id: 'id', label: 'label', type: 'YDumbTab')
+    def tab(filter)
+      Widgets::Tab.new(@widget_controller, Validate.filter(filter))
     end
 
     # Initializes new instance of Table with the filter provided.
@@ -67,12 +117,22 @@ module LibyuiClient
     # @param filter [Hash] filter to find a widget
     # @return [Widgets::Textbox] new instance of Textbox
     # @example
-    #   app.checkbox(id: 'id', label: 'label', type: 'YInputField')
+    #   app.textbox(id: 'id', label: 'label', type: 'YInputField')
     def textbox(filter)
       Widgets::Textbox.new(@widget_controller, Validate.filter(filter))
     end
 
-    # Initializes new instance of wizard with the filter provided.
+    # Initializes new instance of Tree with the filter provided.
+    # Does not make request to libyui-rest-api.
+    # @param filter [Hash] filter to find a widget
+    # @return [Widgets::Tree] new instance of Tree
+    # @example
+    #   app.tree(id: 'id', label: 'label', type: 'YTree')
+    def tree(filter)
+      Widgets::Tree.new(@widget_controller, Validate.filter(filter))
+    end
+
+    # Initializes new instance of Wizard with the filter provided.
     # Does not make request to libyui-rest-api.
     # @param filter [Hash] filter to find a widget
     # @return [Widgets::Wizard] new instance of Wizard
@@ -80,26 +140,6 @@ module LibyuiClient
     #   app.wizard(id: 'id', label: 'label', type: 'YWizard')
     def wizard(filter)
       Widgets::Wizard.new(@widget_controller, Validate.filter(filter))
-    end
-
-    # Initializes new instance of label with the filter provided.
-    # Does not make request to libyui-rest-api.
-    # @param filter [Hash] filter to find a widget
-    # @return [Widgets::Label] new instance of Label
-    # @example
-    #   app.label(id: 'id', label: 'label', type: 'YLabel')
-    def label(filter)
-      Widgets::Label.new(@widget_controller, Validate.filter(filter))
-    end
-
-    # Initializes new instance of richtext with the filter provided.
-    # Does not make request to libyui-rest-api.
-    # @param filter [Hash] filter to find a widget
-    # @return [Widgets::Richtext] new instance of Richtext
-    # @example
-    #   app.richtext(id: 'id', label: 'label', type: 'YLabel')
-    def richtext(filter)
-      Widgets::Richtext.new(@widget_controller, Validate.filter(filter))
     end
   end
 end

--- a/lib/libyui_client/waitable.rb
+++ b/lib/libyui_client/waitable.rb
@@ -5,7 +5,7 @@ module LibyuiClient
     # Waits until the block evaluation will return true, raises Error::TimeoutError on timeout.
     # @param timeout [Numeric] how long to wait (in seconds). Default is LibyuiClient.timeout.
     # @param interval [Numeric] time in seconds between attempts. Default is LibyuiClient.interval.
-    # @message [String] message to be sent in case timeout is reached.
+    # @param message [String] message to be sent in case timeout is reached.
     # @raise Error::TimeoutError
     # @return [Waitable] waitable object
     # @example Wait for checkbox to be checked
@@ -22,7 +22,7 @@ module LibyuiClient
     # Waits while the block evaluation returns true, raises Error::TimeoutError on timeout.
     # @param timeout [Numeric] how long to wait (in seconds). Default is LibyuiClient.timeout.
     # @param interval [Numeric] time in seconds between attempts. Default is LibyuiClient.interval.
-    # @message [String] message to be sent in case timeout is reached.
+    # @param message [String] message to be sent in case timeout is reached.
     # @raise Error::TimeoutError
     # @return [Waitable] waitable object
     # @example Wait for checkbox to be unchecked

--- a/lib/libyui_client/widgets.rb
+++ b/lib/libyui_client/widgets.rb
@@ -7,11 +7,16 @@ module LibyuiClient
     require 'libyui_client/widgets/button'
     require 'libyui_client/widgets/checkbox'
     require 'libyui_client/widgets/combobox'
+    require 'libyui_client/widgets/label'
+    require 'libyui_client/widgets/menubutton'
+    require 'libyui_client/widgets/numberbox'
     require 'libyui_client/widgets/radiobutton'
+    require 'libyui_client/widgets/tab'
     require 'libyui_client/widgets/table'
     require 'libyui_client/widgets/textbox'
     require 'libyui_client/widgets/label'
     require 'libyui_client/widgets/richtext'
+    require 'libyui_client/widgets/tree'
     # Class representing a Wizard UI. It can be YWizard
     class Wizard < Widgets::Base
     end

--- a/lib/libyui_client/widgets/base.rb
+++ b/lib/libyui_client/widgets/base.rb
@@ -39,7 +39,7 @@ module LibyuiClient
 
       # Returns debug_label value for widget.
       # Can be called against any widget.
-      # @return debug_label [String] value of debug_label property
+      # @return [String] value of debug_label property
       # @example Get debug_label value for button
       #   {
       #     "class": "YQWizardButton",
@@ -49,7 +49,7 @@ module LibyuiClient
       #     "label": "&Cancel"
       #   }
       # @example
-      #   fkey = app.button(id: 'cancel').debug_label # "Cancel"
+      #   debug_label = app.button(id: 'cancel').debug_label # Cancel
       def debug_label
         property(:debug_label)
       end

--- a/lib/libyui_client/widgets/button.rb
+++ b/lib/libyui_client/widgets/button.rb
@@ -14,7 +14,7 @@ module LibyuiClient
       end
 
       # Returns fkey value for the button.
-      # @return fkey [Integer] F (function) key that can be used as shortcut to press the button.
+      # @return [Integer] F (function) key that can be used as shortcut to press the button.
       # @example Get fkey value for YQWizardButton
       #   {
       #     "class": "YQWizardButton",
@@ -24,7 +24,7 @@ module LibyuiClient
       #     "label": "&Cancel"
       #   }
       # @example
-      #   fkey = app.button(id: 'cancel').fkey # 9
+      #   fkey = app.button(id: 'cancel').fkey
       def fkey
         property(:fkey)
       end

--- a/lib/libyui_client/widgets/checkbox.rb
+++ b/lib/libyui_client/widgets/checkbox.rb
@@ -4,30 +4,12 @@ module LibyuiClient
   module Widgets
     # Class representing a Checkbox in UI. It can be YCheckBox.
     class Checkbox < Widgets::Base
-      # Sends action to toggle the checkbox in UI (i.e. uncheck when checked, or check otherwise).
-      # @return [Checkbox] in case action is successful
-      # @example Toggle checkbox with id 'test'
-      #   app.checkbox(id: 'test').toggle
-      def toggle
-        action(action: Actions::TOGGLE)
-        self
-      end
-
       # Sends action to explicitly check the checkbox in UI (regardless of the current state).
       # @return [Checkbox] in case action is successful
       # @example Check checkbox with id 'test'
       #   app.checkbox(id: 'test').check
       def check
         action(action: Actions::CHECK)
-        self
-      end
-
-      # Sends action to explicitly uncheck the checkbox in UI (regardless of the current state).
-      # @return [Checkbox] in case action is successful
-      # @example Uncheck checkbox with id 'test'
-      #   checkbox(id: 'test').uncheck
-      def uncheck
-        action(action: Actions::UNCHECK)
         self
       end
 
@@ -47,6 +29,24 @@ module LibyuiClient
       #   app.checkbox(id: 'change_now').checked? # true
       def checked?
         property(:value)
+      end
+
+      # Sends action to toggle the checkbox in UI (i.e. uncheck when checked, or check otherwise).
+      # @return [Checkbox] in case action is successful
+      # @example Toggle checkbox with id 'test'
+      #   app.checkbox(id: 'test').toggle
+      def toggle
+        action(action: Actions::TOGGLE)
+        self
+      end
+
+      # Sends action to explicitly uncheck the checkbox in UI (regardless of the current state).
+      # @return [Checkbox] in case action is successful
+      # @example Uncheck checkbox with id 'test'
+      #   checkbox(id: 'test').uncheck
+      def uncheck
+        action(action: Actions::UNCHECK)
+        self
       end
     end
   end

--- a/lib/libyui_client/widgets/combobox.rb
+++ b/lib/libyui_client/widgets/combobox.rb
@@ -4,39 +4,8 @@ module LibyuiClient
   module Widgets
     # Class representing a ComboBox in the UI. It can be YComboBox.
     class Combobox < Widgets::Base
-      # Sends action to select the item in combobox.
-      # @param item [String] item to select in combobox.
-      # List of items can be retrieved from JSON "items"->"label" manually or by using 'combobox(filter).items'.
-      # @return [Combobox] in case action is successful
-      # @raise LibyuiClient::Error::ItemNotFoundInWidgetError in case value is not found in combobox.
-      # @example Select "Force NFSv3" item in combobox with id "nfs_version"
-      #   {
-      #     "class": "YComboBox",
-      #     "debug_label": "NFS Version",
-      #     "icon_base_path": "",
-      #     "id": "nfs_version",
-      #     "items": [
-      #       {
-      #         "label": "Any (Highest Available)",
-      #         "selected": true
-      #       },
-      #       {
-      #         "label": "Force NFSv3"
-      #       }
-      #     ],
-      #     "items_count": 5,
-      #     "label": "NFS &Version",
-      #     "value": "Any (Highest Available)"
-      #   }
-      # @example
-      #   app.combobox(id: 'nfs_version').select('Force NFSv3')
-      def select(item)
-        action(action: Actions::SELECT, value: item)
-        self
-      end
-
       # Returns the list of items available to select from combobox.
-      # @return [Array] array of Strings.
+      # @return [Array<String>] array of strings.
       # @example Get items from combobox with id "nfs_version"
       #   {
       #     "class": "YComboBox",
@@ -62,6 +31,18 @@ module LibyuiClient
       #   # Force NFSv3
       def items
         property(:items).map { |x| x[:label] }
+      end
+
+      # Sends action to select the item in combobox.
+      # @param item [String] item to select in combobox.
+      # List of items can be retrieved from JSON "items"->"label" manually or by using 'combobox(filter).items'.
+      # @return [Combobox] in case action is successful
+      # @raise LibyuiClient::Error::ItemNotFoundInWidgetError in case value is not found in combobox.
+      # @example Select "Force NFSv3" item in combobox with id "nfs_version"
+      #   app.combobox(id: 'nfs_version').select('Force NFSv3')
+      def select(item)
+        action(action: Actions::SELECT, value: item)
+        self
       end
 
       # Returns selected item in combobox.

--- a/lib/libyui_client/widgets/label.rb
+++ b/lib/libyui_client/widgets/label.rb
@@ -4,21 +4,6 @@ module LibyuiClient
   module Widgets
     # Class representing a Label UI. It can be YLabel, YLabel_Heading
     class Label < Widgets::Base
-      # Returns text value for the label.
-      # @return [String] value
-      # @example Get text value for YLabel, YLabelHeading
-      #   {
-      #     "class": "YLabel",
-      #     "debug_label": "short message",
-      #     "label": "test label",
-      #     "text": "text label"
-      #   }
-      # @example
-      #   text = app.label(label: 'test label').text # "text label"
-      def text
-        property(:text)
-      end
-
       # Returns if label is a heading being represented in bold in the UI
       # Gets value from 'is_heading' parameter in JSON representation of YLabel_Heading.
       # @return [Boolean] true if it is a heading, false otherwise.
@@ -35,6 +20,21 @@ module LibyuiClient
       def heading?
         heading_prop = property(:is_heading)
         !heading_prop.nil? && heading_prop == true
+      end
+
+      # Returns text value for the label.
+      # @return [String] value
+      # @example Get text value for YLabel, YLabelHeading
+      #   {
+      #     "class": "YLabel",
+      #     "debug_label": "short message",
+      #     "label": "test label",
+      #     "text": "text label"
+      #   }
+      # @example
+      #   text = app.label(label: 'test label').text # "text label"
+      def text
+        property(:text)
       end
     end
   end

--- a/lib/libyui_client/widgets/menubutton.rb
+++ b/lib/libyui_client/widgets/menubutton.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module LibyuiClient
+  module Widgets
+    # Class representing a menubutton in UI. It can be YMenuButton.
+    class Menubutton < Widgets::Base
+      # Sends action to click on one of the items of the menubutton in UI.
+      # @param item [String] value to select from items.
+      # @example Click button with label 'test_button' for menubutton with id 'test_id'.
+      # @example
+      #   app.menubutton(id: 'test_id').click('test_button')
+      def click(item)
+        action(action: Actions::PRESS, value: item)
+      end
+
+      # Returns the list of items available to select from widget.
+      # @return [Array<String>] array of strings.
+      # @example Get items from widget with id "test_id"
+      #   {
+      #     "class": "YMenuButton",
+      #     "debug_label": "test",
+      #     "icon_base_path": "",
+      #     "id": "test_id",
+      #     "items": [
+      #       {
+      #         "label": "button1"
+      #       },
+      #       {
+      #         "label": "button2"
+      #       },
+      #       {
+      #         "label": "button3"
+      #       }
+      #     ],
+      #     "items_count": 3,
+      #     "label": "button group"
+      #   }
+      # @example
+      #   app.menubutton(id: 'test').items
+      #   # button1
+      #   # button2
+      #   # button3
+      def items
+        property(:items).map { |x| x[:label] }
+      end
+    end
+  end
+end

--- a/lib/libyui_client/widgets/numberbox.rb
+++ b/lib/libyui_client/widgets/numberbox.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module LibyuiClient
+  module Widgets
+    # Class representing a numberbox in the UI. It can be YIntField.
+    class Numberbox < Widgets::Base
+      # Returns minimum value to set in the numberbox
+      # @return [Integer] with minimum value
+      # @example Get minimum value to set numberbox with id 'test'
+      #   {
+      #      "class": "YIntField",
+      #      "debug_label": "label_test",
+      #      "hstretch": true,
+      #      "id": "test",
+      #      "label": "label_test",
+      #      "max_value": 65535,
+      #      "min_value": 0,
+      #      "value": 3260
+      #   }
+      # @example
+      #   app.numberbox(id: 'test').min_value
+      def min_value
+        property(:min_value)
+      end
+
+      # Returns maximum value to set in the numberbox
+      # @return [Integer] with maximum value
+      # @example Get maximum value to set numberbox with id 'test'
+      #   {
+      #      "class": "YIntField",
+      #      "debug_label": "label_test",
+      #      "hstretch": true,
+      #      "id": "test",
+      #      "label": "label_test",
+      #      "max_value": 65535,
+      #      "min_value": 0,
+      #      "value": 3260
+      #   }
+      # @example
+      #   app.numberbox(id: 'test').max_value
+      def max_value
+        property(:max_value)
+      end
+
+      # Sends action to set the value of numberbox.
+      # @param value [Integer] to be set in numberbox
+      # @return [Numberbox] in case action is successful
+      # @example Set text in numberbox with id 'test' to 123
+      #   app.numberbox(id: 'test').set(123)
+      def set(value)
+        action(action: Actions::ENTER_TEXT, value: value)
+        self
+      end
+
+      # Returns number that is currently set for numberbox.
+      # Gets value from 'value' parameter in JSON representation of YIntField.
+      # @return [Integer] value
+      # @example Get value from numberbox with id "test"
+      #   {
+      #      "class": "YIntField",
+      #      "debug_label": "label_test",
+      #      "hstretch": true,
+      #      "id": "test",
+      #      "label": "label_test",
+      #      "max_value": 65535,
+      #      "min_value": 0,
+      #      "value": 3260
+      #   }
+      # @example
+      #   app.numberbox(id: 'address').value # 3260
+      def value
+        property(:value)
+      end
+    end
+  end
+end

--- a/lib/libyui_client/widgets/richtext.rb
+++ b/lib/libyui_client/widgets/richtext.rb
@@ -25,7 +25,7 @@ module LibyuiClient
       #     "text": "<small>Select something here</small>",
       #     "vstretch": true,
       #     "vweight": 25
-      # }
+      #   }
       # @example
       #   text = app.richtext(id: 'test').text # "<small>Select something here</small>"
       def text

--- a/lib/libyui_client/widgets/tab.rb
+++ b/lib/libyui_client/widgets/tab.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module LibyuiClient
+  module Widgets
+    # Class representing a tab in the UI. It can be YDumbTab.
+    class Tab < Widgets::Base
+      # Returns the list of items available to select from tab.
+      # @return [Array] array of String objects.
+      # @example Get items from tab with id "test_id"
+      #   {
+      #     "class": "YDumbTab",
+      #     "debug_label": "YDumbTab [tab1] [tab2] [tab3]",
+      #     "hstretch": true,
+      #     "icon_base_path": "",
+      #     "id": "test_id",
+      #     "items": [
+      #       {
+      #         "label": "tab1"
+      #       },
+      #       {
+      #         "label": "tab2",
+      #         "selected": true
+      #       },
+      #       {
+      #         "label": "tab3"
+      #       }
+      #     ],
+      #     "items_count": 3,
+      #     "vstretch": true
+      #   }
+      # @example
+      #   app.tab(id: 'test').items
+      #   # tab1
+      #   # tab2
+      #   # tab3
+      def items
+        property(:items).map { |x| x[:label] }
+      end
+
+      # Sends action to click the tab in UI.
+      # @param item [String] value to select from items.
+      # @return [Tab] in case action is successful
+      # @example Click tab with id 'test'
+      #   app.button(id: 'test', value: test_item).select
+      def select(item)
+        action(action: Actions::SELECT, value: item)
+        self
+      end
+
+      # Returns the label of the selected tab.
+      # @return [String] label of the tab selected
+      # @example Get items from tab with id "test_id"
+      #   {
+      #     "class": "YDumbTab",
+      #     "debug_label": "YDumbTab [tab1] [tab2] [tab3]",
+      #     "hstretch": true,
+      #     "icon_base_path": "",
+      #     "id": "test_id",
+      #     "items": [
+      #       {
+      #         "label": "tab1"
+      #       },
+      #       {
+      #         "label": "tab2",
+      #         "selected": true
+      #       },
+      #       {
+      #         "label": "tab3"
+      #       }
+      #     ],
+      #     "items_count": 3,
+      #     "vstretch": true
+      #   }
+      # @example
+      #   app.tab(id: 'test').selected_item  # tab2
+      def selected_item
+        property(:items).select { |x| x[:selected] }.first[:label]
+      end
+    end
+  end
+end

--- a/lib/libyui_client/widgets/table.rb
+++ b/lib/libyui_client/widgets/table.rb
@@ -4,35 +4,130 @@ module LibyuiClient
   module Widgets
     # Class representing a table in the UI. It can be YTable
     class Table < Widgets::Base
-      # Sends action to select a row in a table.
-      # @param value [String] value to select in the table.
-      # @param column_id [Integer] number of column in zero-based numbering format (i.e. the first column is 0)
-      # @return [Table] in case action is successful
-      # @example Select "test.item.2" in the table
+      # Returns whether the table contains any row or not
+      # @return [Boolean] true if table is empty, otherwise false
+      # @example Check if table with id "test_id" is empty
       #     {
       #       "class": "YTable",
-      #       "columns": 1,
-      #       "id": "test_table",
+      #       "columns": 4,
+      #       "header": [
+      #         "header1",
+      #         "header2",
+      #         "header3",
+      #         "header4"
+      #       ],
+      #       "id": "test_id",
+      #       "items": null,
+      #       "items_count": 0
+      #     }
+      # @example
+      #   app.table(id: 'test_id').empty?
+      def empty?
+        property(:items).nil?
+      end
+
+      # Returns the list of items available to select from the table.
+      # @return [Array] array of [Array] objects containing values for each column
+      # @example Get items from the table with id "test_id"
+      #     {
+      #       "class": "YTable",
+      #       "columns": 4,
+      #       "header": [
+      #         "header1",
+      #         "header2",
+      #         "header3",
+      #         "header4"
+      #       ],
+      #       "id": "test_id",
       #       "items": [
       #           {
       #               "labels": [
-      #                   "test.item.1"
+      #                   "test.item.1",
+      #                   "",
+      #                   "",
+      #                   ""
       #               ],
       #               "selected": true
       #           },
       #           {
       #               "labels": [
-      #                     "test.item.2"
+      #                   "test.item.2",
+      #                   "",
+      #                   "",
+      #                   ""
       #               ]
       #           }
       #       ],
       #       "items_count": 2
       #     }
       # @example
-      #   app.table(id: 'test_table').select_row(value: 'test.item.2', column_id: 0)
-      def select_row(value:, column_id:)
-        action(action: Actions::SELECT, value: value, column: column_id)
+      #   app.table(id: 'test_id').items
+      #   # [test.item.1, "", "", ""]
+      #   # [test.item.2, "", "", ""]
+      def items
+        property(:items).map { |x| x[:labels] }
+      end
+
+      # Sends action to select a row in a table.
+      # @param value [String] value to select in the table.
+      # @param column [String] column name where value is present
+      # @return [Table] in case action is successful
+      # @example Select row with value "test.item.2" for column "header1" in table with id 'test_id'
+      #   app.table(id: 'test_id').select(value: 'test.item.2', column: header1)
+      def select(value:, column: '')
+        params = { action: Actions::SELECT, value: value }
+        params.merge!(column: get_index(column)) unless column.empty?
+        action(params)
         self
+      end
+
+      # Returns the list of items currently selected from the table.
+      # @return [Array] array of [Array] objects containing values for each column
+      # @example Get items from the table with id "test_id"
+      #     {
+      #       "class": "YTable",
+      #       "columns": 4,
+      #       "header": [
+      #         "header1",
+      #         "header2",
+      #         "header3",
+      #         "header4"
+      #       ],
+      #       "id": "test_id",
+      #       "items": [
+      #           {
+      #               "labels": [
+      #                   "test.item.1",
+      #                   "",
+      #                   "",
+      #                   ""
+      #               ],
+      #               "selected": true
+      #           },
+      #           {
+      #               "labels": [
+      #                   "test.item.2",
+      #                   "",
+      #                   "",
+      #                   ""
+      #               ],
+      #               "selected": true
+      #           }
+      #       ],
+      #       "items_count": 2
+      #     }
+      # @example
+      #   app.table(id: 'test_id').selected_items
+      #   # [test.item.1, "", "", ""]
+      #   # [test.item.2, "", "", ""]
+      def selected_items
+        property(:items).map { |x| x[:labels] if x[:selected] }.compact
+      end
+
+      private
+
+      def get_index(column)
+        property(:header).index(column)
       end
     end
   end

--- a/lib/libyui_client/widgets/textbox.rb
+++ b/lib/libyui_client/widgets/textbox.rb
@@ -4,6 +4,26 @@ module LibyuiClient
   module Widgets
     # Class representing a textbox in the UI. It can be YInputField.
     class Textbox < Widgets::Base
+      # Returns maximum string length to set in the textbox
+      # @return [Integer] maximum number of character to set in the textbox
+      # @example Check maximum string length in textbox with id 'test'
+      #   {
+      #      "class": "YInputField",
+      #      "debug_label": "label_test",
+      #      "hstretch": true,
+      #      "id": "test",
+      #      "input_max_length": 256,
+      #      "label": "label_test",
+      #      "password_mode": false,
+      #      "valid_chars": "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.",
+      #      "value": ""
+      #   }
+      # @example
+      #   app.textbox(id: 'test').max_length
+      def max_length
+        property(:input_max_length)
+      end
+
       # Sends action to set the value of textbox.
       # @param value [String] text to be set in textbox
       # @return [Textbox] in case action is successful
@@ -12,6 +32,43 @@ module LibyuiClient
       def set(value)
         action(action: Actions::ENTER_TEXT, value: value)
         self
+      end
+
+      # Check if textbox has password mode
+      # @return [Boolean] true if has password mode, otherwise false
+      # @example Check password mode in textbox with id 'test'
+      #   {
+      #      "class": "YInputField",
+      #      "debug_label": "label_test",
+      #      "hstretch": true,
+      #      "id": "test",
+      #      "label": "label_test",
+      #      "password_mode": false,
+      #      "value": ""
+      #   }
+      # @example
+      #   app.textbox(id: 'test').password?
+      def password?
+        property(:password_mode)
+      end
+
+      # Returns valid chars to set in the textbox
+      # @return [String] containing all valid chars
+      # @example Check password mode in textbox with id 'test'
+      #   {
+      #      "class": "YInputField",
+      #      "debug_label": "label_test",
+      #      "hstretch": true,
+      #      "id": "test",
+      #      "label": "label_test",
+      #      "password_mode": false,
+      #      "valid_chars": "0123456789",
+      #      "value": ""
+      #   }
+      # @example
+      #   app.textbox(id: 'test').valid_chars
+      def valid_chars
+        property(:valid_chars)
       end
 
       # Returns text that is currently set for textbox.

--- a/lib/libyui_client/widgets/tree.rb
+++ b/lib/libyui_client/widgets/tree.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+module LibyuiClient
+  module Widgets
+    # Class representing a tree in UI. It can be YTree.
+    class Tree < Widgets::Base
+      # Returns the list of items available to select from tree. Each item
+      # is represented by its path from root node to leaf in the tree,
+      # in other words, a list of nodes separated by special simbol '|'
+      # @return [Array<String>] array of strings
+      # @example Get items from tree with id "test_id"
+      #  {
+      #    "class": "YTree",
+      #    "debug_label": "node_0",
+      #    "hstretch": true,
+      #    "hweight": 30,
+      #    "icon_base_path": "",
+      #    "id": "test_id",
+      #    "items": [
+      #      {
+      #        "children": [
+      #          {
+      #            "icon_name": "icon",
+      #            "label": "node1_1"
+      #          },
+      #          {
+      #            "children": [
+      #              {
+      #                "label": "node1_2_1"
+      #              },
+      #              {
+      #                "label": "node1_2_2",
+      #                "selected": true
+      #              }
+      #            ],
+      #            "icon_name": "icon",
+      #            "label": "node1_2"
+      #          }
+      #        ],
+      #        "icon_name": "icon",
+      #        "label": "node1",
+      #      },
+      #      {
+      #        "icon_name": "icon",
+      #        "label": "node2"
+      #      }
+      #    ],
+      #    "items_count": 2,
+      #    "label": "node_0",
+      #    "notify": true,
+      #    "vstretch": true
+      #  }
+      # @example
+      #   app.tree(id: 'test_id').items
+      #   # node1
+      #   # node1|node1_1
+      #   # node1|node1_2
+      #   # node1|node1_2|node1_2_1
+      #   # node1|node1_2|node1_2_2
+      #   # node2
+      def items
+        get_nodes(property(:items))
+      end
+
+      # Sends action to select an item from the tree in UI.
+      # @param item [String] value to select from items.
+      # @example Select tree node 'test_node' from tree with id 'test_id'
+      #   app.tree(id: 'test_id').select('test_node')
+      def select(item)
+        action(action: Actions::SELECT, value: item)
+        self
+      end
+
+      # Returns the item currently selected/highlighted in the tree. Item
+      # is represented by its path from root node to leaf in the tree,
+      # in other words, a list of nodes separated by special simbol '|'
+      # @return [String] item selected/highlighted in the tree
+      # @example Get selected item from tree with id "test_id"
+      #  {
+      #    "class": "YTree",
+      #    "debug_label": "node_0",
+      #    "hstretch": true,
+      #    "hweight": 30,
+      #    "icon_base_path": "",
+      #    "id": "test_id",
+      #    "items": [
+      #      {
+      #        "children": [
+      #          {
+      #            "icon_name": "icon",
+      #            "label": "node1_1"
+      #          },
+      #          {
+      #            "children": [
+      #              {
+      #                "label": "node_1_2_1"
+      #              },
+      #              {
+      #                "label": "node_1_2_2",
+      #                "selected": true
+      #              }
+      #            ],
+      #            "icon_name": "icon",
+      #            "label": "node1_2"
+      #          }
+      #        ],
+      #        "icon_name": "icon",
+      #        "label": "node1",
+      #      },
+      #      {
+      #        "icon_name": "icon",
+      #        "label": "node2"
+      #      }
+      #    ],
+      #    "items_count": 2,
+      #    "label": "node_0",
+      #    "notify": true,
+      #    "vstretch": true
+      #  }
+      # @example
+      #   app.tree(id: 'test_id').selected_item
+      #   # node1|node1_2|node1_2_2
+      def selected_item
+        get_selected_node(property(:items))
+      end
+
+      private
+
+      def get_nodes(items, root = '')
+        items.map do |x|
+          current = root.empty? ? x[:label] : root + '|' + x[:label]
+          x.key?(:children) ? [current, get_nodes(x[:children], current)] : current
+        end.flatten
+      end
+
+      def get_selected_node(items, root = '')
+        selected = ''
+        items.each do |x|
+          current = root.empty? ? x[:label] : root + '|' + x[:label]
+          return current if x[:selected]
+
+          selected = get_selected_node(x[:children], current) if x.key?(:children)
+          break unless selected.empty?
+        end
+        selected
+      end
+    end
+  end
+end

--- a/spec/unit/widgets/menubutton_spec.rb
+++ b/spec/unit/widgets/menubutton_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+module LibyuiClient
+  module Widgets
+    RSpec.describe Menubutton do
+      let(:widget_controller) { instance_double('widget_controller') }
+      let(:filter) { { id: 'foo' } }
+      subject { Menubutton.new(widget_controller, filter) }
+      let(:button1) { 'button1' }
+      let(:button2) { 'button2' }
+      let(:buttons) { [button1, button2] }
+
+      describe '#click' do
+        let(:response) { double('Response') }
+        it 'sends click action' do
+          expect(widget_controller).to receive(:send_action).and_return(response)
+          expect(subject.click(button2)).to equal(response)
+        end
+      end
+
+      describe '#items' do
+        let(:response) do
+          double('Response', { body: [{ items: [{ label: button1 }, { label: button2 }] }] })
+        end
+        it 'lists items' do
+          expect(widget_controller).to receive(:find).and_return(response)
+          expect(subject.items).to match_array(buttons)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/widgets/numberbox_spec.rb
+++ b/spec/unit/widgets/numberbox_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+module LibyuiClient
+  module Widgets
+    RSpec.describe Numberbox do
+      let(:widget_controller) { instance_double('widget_controller') }
+      let(:filter) { { id: 'aliases' } }
+      subject { Numberbox.new(widget_controller, filter) }
+
+      describe '#min_value' do
+        let(:response) { double('Response', { body: [{ min_value: 0 }] }) }
+        it 'returns min value' do
+          expect(widget_controller).to receive(:find).and_return(response)
+          expect(subject.min_value).to eq(0)
+        end
+      end
+
+      describe '#max_value' do
+        let(:response) { double('Response', { body: [{ max_value: 65_535 }] }) }
+        it 'returns max value' do
+          expect(widget_controller).to receive(:find).and_return(response)
+          expect(subject.max_value).to eq(65_535)
+        end
+      end
+
+      describe '#set' do
+        it 'sets text' do
+          expect(widget_controller).to receive(:send_action)
+          expect(subject.set(8686)).to equal(subject)
+        end
+      end
+
+      describe '#value' do
+        let(:response) { double('Response', { body: [{ value: 'test' }] }) }
+        it 'returns value currently set' do
+          expect(widget_controller).to receive(:find).and_return(response)
+          expect(subject.value).to eq('test')
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/widgets/tab_spec.rb
+++ b/spec/unit/widgets/tab_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+module LibyuiClient
+  module Widgets
+    RSpec.describe Tab do
+      let(:widget_controller) { instance_double('widget_controller') }
+      let(:filter) { { id: 'foo' } }
+      subject { Tab.new(widget_controller, filter) }
+      let(:tab1) { 'tab1' }
+      let(:tab2) { 'tab2' }
+      let(:tabs) { [tab1, tab2] }
+      let(:response) do
+        double('Response', { body: [{ items: [{ label: 'tab1' }, { label: 'tab2', selected: true }] }] })
+      end
+
+      describe '#items' do
+        it 'lists items' do
+          expect(widget_controller).to receive(:find).and_return(response)
+          expect(subject.items).to match_array(tabs)
+        end
+      end
+
+      describe '#select' do
+        it 'selects tab' do
+          expect(widget_controller).to receive(:send_action)
+          expect(subject.select(tab2)).to equal(subject)
+        end
+      end
+
+      describe '#selected_item' do
+        it 'returs selected item' do
+          expect(widget_controller).to receive(:find).and_return(response)
+          expect(subject.selected_item).to eql(tab2)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/widgets/table_spec.rb
+++ b/spec/unit/widgets/table_spec.rb
@@ -6,13 +6,68 @@ module LibyuiClient
   module Widgets
     RSpec.describe Table do
       let(:widget_controller) { instance_double('widget_controller') }
-      let(:widget_filter) { { id: 'foo' } }
-      subject { Table.new(widget_controller, widget_filter) }
-      describe '#select_row' do
-        it 'sends select action' do
+      let(:filter) { { id: 'foo' } }
+      let(:header_0) { 'header_0' }
+      let(:header_1) { 'header_1' }
+      let(:headers) { [header_0, header_1] }
+      let(:cell_0_0) { 'cell_0_0' }
+      let(:cell_1_0) { 'cell_1_0' }
+      let(:row_0) { [cell_0_0, '', '', ''] }
+      let(:row_1) { [cell_1_0, '', '', ''] }
+      let(:rows) { [row_0, row_1] }
+      let(:table_with_rows) do
+        double('Response', { body: [{ items: [{ labels: row_0 }, { labels: row_1, selected: true }] }] })
+      end
+      subject { Table.new(widget_controller, filter) }
+
+      describe '#empty?' do
+        context 'when table is empty' do
+          let(:table_empty) { double('Response', { body: [{ items: nil }] }) }
+          it 'returns true' do
+            allow(widget_controller).to receive(:find).and_return(table_empty)
+            expect(subject.empty?).to be_truthy
+          end
+        end
+        context 'when table contains rows' do
+          it 'returns false' do
+            allow(widget_controller).to receive(:find).and_return(table_with_rows)
+            expect(subject.empty?).to be_falsy
+          end
+        end
+      end
+
+      describe '#items' do
+        it 'lists items' do
+          allow(widget_controller).to receive(:find).and_return(table_with_rows)
+          expect(subject.items).to eql(rows)
+        end
+      end
+
+      describe '#select' do
+        let(:response) { double('Response', { body: [{ header: headers }] }) }
+        before do
+          allow(widget_controller).to receive(:find).and_return(response)
           allow(widget_controller).to receive(:send_action)
-          expect(subject).to receive(:action).with({ action: 'select', column: 0, value: 'test.item.1' })
-          expect(subject.select_row(value: 'test.item.1', column_id: 0)).to be_instance_of(Table)
+        end
+        context 'when column is provided' do
+          it 'sends select action' do
+            expect(subject).to receive(:action).with({ action: 'select', value: cell_0_0, column: 0 })
+            expect(subject.select(value: cell_0_0, column: header_0)).to equal(subject)
+          end
+        end
+        context 'when column is not provided' do
+          it 'sends select action' do
+            expect(subject).to receive(:action).with({ action: 'select', value: cell_0_0 })
+            expect(subject.select(value: cell_0_0)).to equal(subject)
+          end
+        end
+      end
+
+      describe '#selected_items' do
+        let(:rows_selected) { [row_1] }
+        it 'lists selected items' do
+          allow(widget_controller).to receive(:find).and_return(table_with_rows)
+          expect(subject.selected_items).to eql(rows_selected)
         end
       end
     end

--- a/spec/unit/widgets/textbox_spec.rb
+++ b/spec/unit/widgets/textbox_spec.rb
@@ -6,26 +6,44 @@ module LibyuiClient
   module Widgets
     RSpec.describe Textbox do
       let(:widget_controller) { instance_double('widget_controller') }
-      let(:widget_filter) { { id: 'aliases' } }
-      subject { Textbox.new(widget_controller, widget_filter) }
+      let(:filter) { { id: 'aliases' } }
+      subject { Textbox.new(widget_controller, filter) }
+
+      describe '#max_length' do
+        let(:response) { double('Response', { body: [{ input_max_length: 256 }] }) }
+        it 'returns input max length' do
+          expect(widget_controller).to receive(:find).and_return(response)
+          expect(subject.max_length).to eq(256)
+        end
+      end
+
       describe '#set' do
-        it 'sends POST with action enter_text and correct value' do
-          expect(subject).to receive(:action).with({ action: 'enter_text', value: 'test' })
-          subject.set('test')
+        it 'sets text' do
+          expect(widget_controller).to receive(:send_action)
+          expect(subject.set('test')).to equal(subject)
+        end
+      end
+
+      describe '#password?' do
+        let(:response) { double('Response', { body: [{ password_mode: true }] }) }
+        it 'returns password mode' do
+          expect(widget_controller).to receive(:find).and_return(response)
+          expect(subject.password?).to be_truthy
+        end
+      end
+
+      describe '#valid_chars' do
+        let(:response) { double('Response', { body: [{ valid_chars: '0123456789' }] }) }
+        it 'returns valid_chars' do
+          expect(widget_controller).to receive(:find).and_return(response)
+          expect(subject.valid_chars).to eq('0123456789')
         end
       end
 
       describe '#value' do
+        let(:response) { double('Response', { body: [{ value: 'test' }] }) }
         it 'should return the text of the :value' do
-          response = double('Response', { body: [{ 'class': 'InputField',
-                                                   debug_label: 'Host Aliases',
-                                                   hstretch: true,
-                                                   id: 'aliases',
-                                                   label: 'Hos&t Aliases',
-                                                   password_mode: false,
-                                                   value: 'test' }] })
-          allow(widget_controller).to receive(:find).and_return(response)
-          allow(widget_controller).to receive(:property)
+          expect(widget_controller).to receive(:find).and_return(response)
           expect(subject.value).to eq('test')
         end
       end

--- a/spec/unit/widgets/tree_spec.rb
+++ b/spec/unit/widgets/tree_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+module LibyuiClient
+  module Widgets
+    RSpec.describe Tree do
+      let(:widget_controller) { instance_double('widget_controller') }
+      let(:filter) { { id: 'foo' } }
+      subject { Tree.new(widget_controller, filter) }
+      let(:items) do
+        %w[node1 node1|node1_1 node1|node1_2 node1|node1_2|node1_2_1 node1|node1_2|node1_2_2 node2]
+      end
+      let(:response) do
+        double('Response',
+               { body: [{ items: [
+                 {
+                   children: [
+                     {
+                       label: 'node1_1'
+                     },
+                     {
+                       children: [
+                         {
+                           label: 'node1_2_1'
+                         },
+                         {
+                           label: 'node1_2_2',
+                           selected: true
+                         }
+                       ],
+                       label: 'node1_2'
+                     }
+                   ],
+                   label: 'node1'
+                 },
+                 {
+                   label: 'node2'
+                 }
+               ] }] })
+      end
+      let(:node) { 'node1|node1_2|node1_2_2' }
+
+      describe '#items' do
+        it 'lists items' do
+          expect(widget_controller).to receive(:find).and_return(response)
+          expect(subject.items).to match_array(items)
+        end
+      end
+
+      describe '#select' do
+        it 'selects tree node' do
+          expect(widget_controller).to receive(:send_action)
+          expect(subject.select(node)).to equal(subject)
+        end
+      end
+
+      describe '#selected_item' do
+        it 'lists items' do
+          expect(widget_controller).to receive(:find).and_return(response)
+          expect(subject.selected_item).to eql(node)
+        end
+      end
+    end
+  end
+end

--- a/spec/widgets/combobox_spec.rb
+++ b/spec/widgets/combobox_spec.rb
@@ -38,7 +38,7 @@ module LibyuiClient
 
       describe '#items' do
         context 'existing widget' do
-          it 'should return list of Strings' do
+          it 'should return array of strings' do
             get_items
             expect(@app.combobox(id).items).to eq(items_list)
           end
@@ -53,7 +53,7 @@ module LibyuiClient
 
       describe '#selected_item' do
         context 'existing widget' do
-          it 'should return Strings' do
+          it 'should return array of strings' do
             get_items
             expect(@app.combobox(id).selected_item).to eq(select_item)
           end

--- a/spec/widgets/table_spec.rb
+++ b/spec/widgets/table_spec.rb
@@ -8,27 +8,31 @@ module LibyuiClient
       include_context 'WidgetsCommon'
 
       # Request/Response parts
-      let(:query_value_column) { { value: 'test_row', column: 1 } }
+      let(:table_header) { { body: '[{ "header": ["header1","header2"]}]' } }
+      let(:query_value_column) { { value: 'test_row', column: '0' } }
       let(:query_select_row) { { action: 'select' }.merge(query_value_column) }
       let(:query_select) { { query: id.merge(query_select_row) } }
 
       # Stubbed Requests
+      let(:get_header_table) { stub_get_id.to_return(table_header) }
       let(:select_row_in_existing_table) { stub_post.with(query_select) }
       let(:select_row_in_non_existent_table) { stub_post_404.with(query_select) }
-      let(:request_query_value_column) { { value: 'test_row', column_id: 1 } }
+      let(:request_query_value_column) { { value: 'test_row', column: 'header1' } }
 
       describe '#select' do
         context 'existing widget' do
           it 'should succeed' do
+            get_header_table
             select_row_in_existing_table
-            @app.table(id).select_row(request_query_value_column)
+            @app.table(id).select(request_query_value_column)
             expect(select_row_in_existing_table).to have_been_made.once
           end
         end
         context 'non-existent widget' do
           it 'should raise WidgetNotFoundError' do
+            get_header_table
             select_row_in_non_existent_table
-            expect { @app.table(id).select_row(request_query_value_column) }.to raise_error(Error::WidgetNotFoundError)
+            expect { @app.table(id).select(request_query_value_column) }.to raise_error(Error::WidgetNotFoundError)
           end
         end
       end


### PR DESCRIPTION
This PR contains the following changes:
  - Adds new widgets found in Expert Partitioner: Menubutton, Numberbox, Tab, Tree
  - Improves existing widgets: Table and Textbox
  - Adds integration testing (only fixing existing one to pass the CI, we are kind of doing the same thing in uniti testing, instead of stubbing with `double` with we do with `webmock`, therefore I'm not planning to extend it)
  - Adds unit testing for new methods in new widgets and improved ones
  - Orders alphabetically methods names due it was needed in the documentation for sure, but why not to do it in the classes as well!